### PR TITLE
Upgrade spotify-checkstyle-config from 1.0.4 to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,12 +130,12 @@
             <dependency>
               <groupId>com.spotify.checkstyle</groupId>
               <artifactId>spotify-checkstyle-config</artifactId>
-              <version>1.0.4</version>
+              <version>1.0.6</version>
             </dependency>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>6.19</version>
+              <version>8.3</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
These checkstyle rules require com.puppycrawl.tools:puppycrawl 8.X.