### PR TITLE
Upgrade maven-checkstyle-plugin from 2.17 to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 
         <plugin>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
+          <version>3.0.0</version>
           <dependencies>
             <dependency>
               <groupId>com.spotify.checkstyle</groupId>
@@ -135,7 +135,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>8.4</version>
+              <version>8.13</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
and com.puppycrawl.tools:checkstyle from 8.4 to 8.13

These versions are compatible with building on JDK11 which
otherwise fails with trying to find the now removed
`lib/tools.jar`.
See https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-A78CC891-701D-4549-AA4E-B8DD90228B4B.