### PR TITLE
Enable Java 11, document how to set the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ There's still some boilerplate that has to go into your project `pom.xml`. Use t
  </project>
 ```
 
+In addition, if you can build your project with Java 9+ (which probably means
+Java 11), then it's a good idea to set `maven.compiler.release` in your
+project, which will set up the boot classpath properly. For example:
+
+```xml
+<properties>
+  <maven.compiler.release>8</maven.compiler.release>
+</properties>
+```
+
 After setting this up, you'll be able to
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!-- For producing artifacts that are compatible with Java 8, projects
+      should set maven.compiler.release to 8 in their project, and always use
+      java 9+ to build. -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <scm>
@@ -64,10 +69,9 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.8.1</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <showWarnings>true</showWarnings>
             <compilerArgs>
               <compilerArg>-Xlint:all</compilerArg>
             </compilerArgs>
@@ -107,7 +111,7 @@
 
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.22.2</version>
           <executions>
             <execution>
               <goals>
@@ -292,7 +296,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.19</version>
+        <version>2.22.2</version>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
Only setting source and target is not sufficient to produce bytecode
that is properly compatible with Java 8. The new release flag also sets
the bootclasspath so that everything is set up properly.

However, this will need Java 11 for building.

In addition, bump to the latest compile plugin and surefire to ensure
Java 11 compatibility.