### PR TITLE
Automatically use the release flag when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ There's still some boilerplate that has to go into your project `pom.xml`. Use t
  </project>
 ```
 
-In addition, if you can build your project with Java 9+ (which probably means
-Java 11), then it's a good idea to set `maven.compiler.release` in your
-project, which will set up the boot classpath properly. For example:
+By default your project will target Java 8. If you don't need Java 8
+compatibility and you would like to target a later version of Java, set the
+`maven.compiler.release` property in your project, like so:
 
 ```xml
 <properties>
-  <maven.compiler.release>8</maven.compiler.release>
+  <maven.compiler.release>11</maven.compiler.release>
 </properties>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- For producing artifacts that are compatible with Java 8, projects
-      should set maven.compiler.release to 8 in their project, and always use
-      java 9+ to build. -->
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <scm>
@@ -281,6 +276,28 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+      </properties>
+    </profile>
+    <profile>
+      <id>jdk9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <!-- Javac introduced the "release" option only in Java 9+.  It
+          properly sets up source, target and boot classpath for the best
+          compatibility with different versions of Java. -->
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
The release flag provides better compatibility because it also sets the
boot classpath, however it is was introduced only in Java 9.

This approach has already been tested here: https://github.com/spotify/apollo/pull/286.