### PR TITLE
Sonatype documentations suggests latest Nexus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -251,7 +251,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.3</version>
+            <version>1.6.8</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
Apparently the latest Nexus, among other things, has better logging for
failures (which happen a lot). See
https://central.sonatype.org/pages/apache-maven.html
for more info.

A newer Source shouldn't hurt.