### PR TITLE
align with super pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,9 @@
               <id>enforce</id>
               <configuration>
                 <rules>
+                  <requireMavenVersion>
+                    <version>[3.5.4,)</version>
+                  </requireMavenVersion>
                   <requireUpperBoundDeps />
                 </rules>
               </configuration>
@@ -234,7 +237,7 @@
               <execution>
                 <id>attach-sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>jar-no-fork</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
As well as enforcing lower bound of maven version, ref https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html

When doing a release (which by default uses release-profile), the effective pom becomes:
```
        <plugin>
          <artifactId>maven-source-plugin</artifactId>
          <version>3.0.1</version>
          <executions>
            <execution>
              <id>attach-sources</id>
              <goals>
                <goal>jar</goal>
                <goal>jar-no-fork</goal>
              </goals>
            </execution>
          </executions>
        </plugin>
```
And this results source jar being generated and uploaded twice. Some repository system such as Artifactory is usually configured not to allow overwriting existing file, so this would fail the release process.