### PR TITLE
fix NoSuchMethodError with checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,17 +127,12 @@
 
         <plugin>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.1</version>
           <dependencies>
             <dependency>
               <groupId>com.spotify.checkstyle</groupId>
               <artifactId>spotify-checkstyle-config</artifactId>
-              <version>1.0.7</version>
-            </dependency>
-            <dependency>
-              <groupId>com.puppycrawl.tools</groupId>
-              <artifactId>checkstyle</artifactId>
-              <version>8.29</version>
+              <version>1.0.11</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
dependabot upgraded the `com.puppycrawl.tools:checkstyle` dependency of
the maven-checkstyle-plugin in eac05c272 which results in
incompatabilities between the plugin and Checkstyle itself:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check (validate) on project logging: Execution validate of goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:check: java.lang.NoSuchMethodError: 'void com.puppycrawl.tools.checkstyle.DefaultLogger.<init>(java.io.OutputStream, boolean)'

This changes bumps maven-checkstyle-plugin to the latest version (3.1.1)
to fix this. Since the plugin now uses checkstyle 8.29, there is not a
need to pin the version in the plugin's `<dependencies>`. Its also
necessary to update the version of `spotify-checkstyle-config` as the
format of the checkstyle config file has changed.
