### PR TITLE
update maven-javadoc-plugin to latest (3.2.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
 
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.4</version>
+            <version>3.2.0</version>
             <configuration>
               <failOnError>false</failOnError>
             </configuration>
@@ -316,7 +316,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>3.2.0</version>
         <configuration>
           <failOnError>false</failOnError>
           <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
the previous version fails with errors when releasing projects like
https://github.com/spotify/github-java-client:

```
[WARNING] Unable to process class module-info.class in JarAnalyzer File /Users/mattbrown/.m2/repository/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar
org.apache.bcel.classfile.ClassFormatException: Invalid byte tag in constant pool: 19
    at org.apache.bcel.classfile.Constant.readConstant (Constant.java:146)
    at org.apache.bcel.classfile.ConstantPool.<init> (ConstantPool.java:67)
```

which seems related / fixed by https://issues.apache.org/jira/browse/MPIR-370