### PR TITLE
Update root config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 *.iml
 target
+
+*.releaseBackup
+release.properties

--- a/README.md
+++ b/README.md
@@ -87,3 +87,11 @@ mvn deploy
 mvn release:prepare
 mvn release:perform
 ``` 
+
+#### Fail if no tests
+
+By default, from version 16+ any project using `foss-root` will fail if there are not unit-tests.
+
+You can override this behaviour by setting the property `unitTests.failIfNoTests` equal to `false`.
+
+An equivalent `integrationTests.failIfNoTests` exists, but its default is set to `false`.

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven-test-plugins.version>3.1.2</maven-test-plugins.version>
+    <unitTests.failIfNoTests>true</unitTests.failIfNoTests>
+    <integrationTests.failIfNoTests>false</integrationTests.failIfNoTests>
   </properties>
 
   <scm>
@@ -107,24 +110,6 @@
               </goals>
             </execution>
           </executions>
-        </plugin>
-
-        <plugin>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.1.2</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <includes>
-              <include>**/*IT.java</include>
-            </includes>
-          </configuration>
         </plugin>
 
         <plugin>
@@ -317,6 +302,129 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-test-plugins.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>me.fabriciorby</groupId>
+              <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+              <version>1.2.1</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <includes>
+              <include>**/*Test.java</include>
+              <include>**/*Tests.java</include>
+            </includes>
+            <excludes>
+              <exclude>**/*IT.java</exclude>
+              <exclude>**/integrationtests/*.java</exclude>
+              <exclude>**/it/**/*.java</exclude>
+            </excludes>
+            <testFailureIgnore>false</testFailureIgnore>
+            <failIfNoTests>${unitTests.failIfNoTests}</failIfNoTests>
+            <trimStackTrace>false</trimStackTrace>
+            <systemPropertyVariables>
+              <spotify.test.type>unit</spotify.test.type>
+              <spotify.target.dir>${project.build.directory}</spotify.target.dir>
+            </systemPropertyVariables>
+            <!--
+            For tree reporter in console:
+            https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter
+            Full reports are still written in the `target/surefire-reports` folder
+            -->
+            <reportFormat>plain</reportFormat>
+            <statelessTestsetInfoReporter
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
+              <printStacktraceOnError>true</printStacktraceOnError>
+              <printStacktraceOnFailure>true</printStacktraceOnFailure>
+              <printStdoutOnError>true</printStdoutOnError>
+              <printStdoutOnFailure>true</printStdoutOnFailure>
+              <printStdoutOnSuccess>false</printStdoutOnSuccess>
+              <printStderrOnError>true</printStderrOnError>
+              <printStderrOnFailure>true</printStderrOnFailure>
+              <printStderrOnSuccess>false</printStderrOnSuccess>
+            </statelessTestsetInfoReporter>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-test-plugins.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>me.fabriciorby</groupId>
+              <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+              <version>1.2.1</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <trimStackTrace>false</trimStackTrace>
+            <failIfNoTests>${integrationTests.failIfNoTests}</failIfNoTests>
+            <!--
+            For tree reporter in console:
+            https://github.com/fabriciorby/maven-surefire-junit5-tree-reporter
+            Full reports are still written in the `target/surefire-reports` folder
+            -->
+            <reportFormat>plain</reportFormat>
+            <statelessTestsetInfoReporter
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
+              <printStacktraceOnError>true</printStacktraceOnError>
+              <printStacktraceOnFailure>true</printStacktraceOnFailure>
+              <printStdoutOnError>true</printStdoutOnError>
+              <printStdoutOnFailure>true</printStdoutOnFailure>
+              <printStdoutOnSuccess>false</printStdoutOnSuccess>
+              <printStderrOnError>true</printStderrOnError>
+              <printStderrOnFailure>true</printStderrOnFailure>
+              <printStderrOnSuccess>false</printStderrOnSuccess>
+            </statelessTestsetInfoReporter>
+          </configuration>
+          <executions>
+            <execution>
+              <id>integration-test</id>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+              <configuration>
+                <includes>
+                  <include>**/*IT.java</include>
+                  <include>**/integrationtests/*.java</include>
+                  <include>**/it/**/*.java</include>
+                </includes>
+                <excludes>
+                  <exclude>**/*ContainerIT.java</exclude>
+                </excludes>
+                <systemPropertyVariables>
+                  <spotify.test.type>integration</spotify.test.type>
+                  <spotify.target.dir>${project.build.directory}</spotify.target.dir>
+                </systemPropertyVariables>
+              </configuration>
+            </execution>
+            <execution>
+              <id>container-integration-test</id>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+              <configuration>
+                <includes>
+                  <include>**/*ContainerIT.java</include>
+                </includes>
+                <systemPropertyVariables>
+                  <spotify.test.type>container-integration</spotify.test.type>
+                  <spotify.target.dir>${project.build.directory}</spotify.target.dir>
+                </systemPropertyVariables>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.6.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <name>Spotify Root</name>
@@ -88,7 +90,7 @@
 
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.1</version>
+          <version>3.3.0</version>
           <executions>
             <execution>
               <id>enforce</id>
@@ -97,7 +99,7 @@
                   <requireMavenVersion>
                     <version>[3.5.4,)</version>
                   </requireMavenVersion>
-                  <requireUpperBoundDeps />
+                  <requireUpperBoundDeps/>
                 </rules>
               </configuration>
               <goals>
@@ -109,7 +111,7 @@
 
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.1.2</version>
           <executions>
             <execution>
               <goals>
@@ -190,7 +192,7 @@
 
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.1</version>
           <configuration>
             <tagNameFormat>v@{project.version}</tagNameFormat>
             <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
@@ -200,20 +202,84 @@
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-provider-gitexe</artifactId>
-              <version>1.9.4</version>
+              <version>2.0.1</version>
             </dependency>
           </dependencies>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.2.201409121644</version>
+          <version>0.8.10</version>
           <executions>
             <execution>
               <goals>
                 <goal>prepare-agent</goal>
                 <goal>report</goal>
               </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-changelog-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.4.5</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-report-plugin</artifactId>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.5.0</version>
+          <configuration>
+            <failOnError>false</failOnError>
+            <additionalparam>-Xdoclint:none</additionalparam>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.3.0</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.13</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.1.0</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+              <phase>verify</phase>
+              <configuration>
+                <gpgArguments>
+                  <arg>--pinentry-mode</arg>
+                  <arg>loopback</arg>
+                </gpgArguments>
+              </configuration>
             </execution>
           </executions>
         </plugin>
@@ -228,50 +294,19 @@
         <plugins>
           <plugin>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.1.0</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
 
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
-            <configuration>
-              <failOnError>false</failOnError>
-            </configuration>
           </plugin>
 
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
           </plugin>
 
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>
@@ -304,23 +339,15 @@
     <plugins>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.8.1</version>
       </plugin>
       <plugin>
         <artifactId>maven-changelog-plugin</artifactId>
-        <version>2.3</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.22.2</version>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <failOnError>false</failOnError>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
       </plugin>
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,7 @@
           <version>0.8.10</version>
           <executions>
             <execution>
+              <id>report</id>
               <goals>
                 <goal>prepare-agent</goal>
                 <goal>report</goal>
@@ -280,6 +281,40 @@
                   <arg>loopback</arg>
                 </gpgArguments>
               </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <version>3.0.5</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>pre-integration-test</phase>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>com.coveo</groupId>
+          <artifactId>fmt-maven-plugin</artifactId>
+          <!-- 2.9.1 is the last version that can run on Java 8 -->
+          <version>2.9.1</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>format</goal>
+              </goals>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
My team got some open-source projects to maintain and we noticed that the spotify `foss-root` is pretty outdated. This PR should solve some issues:

* Update all plugins that make sense to be updated to their latest versions
* Fix `gpg-plugin` configuration based on problem for anyone using gpg version above 2.1 (which should be everyone as it has been released for a while). Check [sonatype-docs](https://central.sonatype.org/publish/publish-maven/#gpg-signed-components) for more info
* Start to manage surefire & failsafe plugin, improving test report and adding configuration for projects to fail if no unit tests is found on it, but allow overriding it if necessary.