### PR TITLE
Make sure we use the new release plugin in order to release the foss-root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,8 +454,8 @@
           </plugin>
 
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
           </plugin>
 
           <plugin>


### PR DESCRIPTION
We need to use the `central-publishing-maven-plugin`in the release profile since the old ossrh service has been deprecated.